### PR TITLE
Handle fractional tenure horizons when computing reference dates

### DIFF
--- a/src/inference.py
+++ b/src/inference.py
@@ -224,7 +224,11 @@ def _reference_date_for_horizon(record_frame: pd.DataFrame, horizon_years: float
     if "DateofHire" in record_frame:
         hire_date = record_frame["DateofHire"].iloc[0]
         if pd.notna(hire_date):
-            return hire_date + pd.DateOffset(years=horizon_years)
+            # Convert the fractional-year horizon into a timedelta so pandas can
+            # handle non-integer values (e.g., 1.5 years).
+            horizon_in_days = horizon_years * 365.25
+            horizon_delta = pd.to_timedelta(horizon_in_days, unit="D")
+            return hire_date + horizon_delta
     logger.warning("Could not calculate horizon reference date due to missing 'DateofHire'")
     return None
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import inference  # noqa: E402
+
+
+class DummyEstimator:
+    def predict_proba(self, X):
+        # Return deterministic probabilities for testing.
+        return np.array([[0.2, 0.8]])
+
+
+def test_predict_tenure_risk_accepts_fractional_horizon(monkeypatch):
+    record = {"DateofHire": pd.Timestamp("2020-01-01")}
+
+    def fake_prepare_features(records, *, reference_date=None):
+        # Ensure the fractional horizon was translated to a timestamp.
+        assert isinstance(reference_date, pd.Timestamp)
+        return pd.DataFrame({"dummy": [1]})
+
+    monkeypatch.setattr(inference, "prepare_features_for_inference", fake_prepare_features)
+
+    risks = inference.predict_tenure_risk(record, horizons=[1.5], model=DummyEstimator())
+
+    assert len(risks) == 1
+    assert isinstance(risks[0], inference.TenureRisk)
+    assert risks[0].tenure_years == 1.5


### PR DESCRIPTION
## Summary
- translate tenure horizons to time deltas so fractional-year offsets work with pandas
- add a regression test to ensure predict_tenure_risk accepts non-integer horizons without error

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f234635b948330b922a69dd0738630