### PR TITLE
Add GitHub Action to retrain model and upload artifacts

### DIFF
--- a/.github/workflows/retrain-model.yml
+++ b/.github/workflows/retrain-model.yml
@@ -1,0 +1,56 @@
+name: Retrain model
+
+on:
+  workflow_dispatch:
+    inputs:
+      random_seed:
+        description: "Random seed for reproducibility"
+        default: "42"
+        required: false
+      upload_metrics:
+        description: "Upload metrics.json artifact"
+        required: false
+        default: "true"
+
+jobs:
+  retrain:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Retrain model
+        run: |
+          python src/train_model.py \
+            --data HRDataset_v14.csv \
+            --model-output models/best_model.joblib \
+            --metrics-output reports/metrics.json \
+            --random-state "${{ github.event.inputs.random_seed }}"
+
+      - name: Upload model artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: best-model
+          path: models/best_model.joblib
+          if-no-files-found: error
+
+      - name: Upload metrics artifact
+        if: ${{ github.event.inputs.upload_metrics != 'false' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: training-metrics
+          path: reports/metrics.json
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- add a manually triggered workflow that installs dependencies and runs the existing training script
- persist the regenerated best model and metrics as GitHub Action artifacts for download

## Testing
- not run (workflow definition only)


------
https://chatgpt.com/codex/tasks/task_e_68f23579ed2483309ef69a4772303e3b