### PR TITLE
Relax version constraints for ML visualization stack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 pandas==2.3.3
-scikit-learn==1.7.2
+scikit-learn~=1.7.2
 imbalanced-learn==0.14.0
-matplotlib==3.10.6
+matplotlib~=3.10.6
 seaborn==0.13.2
 joblib==1.5.2
-plotly==6.3.1
-streamlit==1.50.0
+plotly~=6.3.1
+streamlit~=1.50.0


### PR DESCRIPTION
## Summary
- relax the scikit-learn, matplotlib, plotly, and streamlit requirements to allow the latest compatible patch releases
- reinstall the dependencies in a fresh virtual environment to confirm the stack resolves successfully

## Testing
- python src/train_model.py
- python src/inference.py

------
https://chatgpt.com/codex/tasks/task_e_6901a99c77dc8330b799b96bc6eeb3cd