### PR TITLE
Introduce shared raw numeric inputs for GUI form

### DIFF
--- a/src/feature_engineering.py
+++ b/src/feature_engineering.py
@@ -41,15 +41,19 @@ DATE_COLUMNS: Sequence[str] = (
     "LastPerformanceReview_Date",
 )
 
-# Numeric features to be used in the model.
-# These will typically be scaled and imputed.
-NUMERIC_FEATURES: Sequence[str] = (
+# Raw numeric inputs that must be provided by the user or source dataset.
+RAW_NUMERIC_INPUTS: Sequence[str] = (
     "Salary",
     "EngagementSurvey",
     "EmpSatisfaction",
     "SpecialProjectsCount",
     "DaysLateLast30",
     "Absences",
+)
+
+# Numeric features to be used in the model.
+# These will typically be scaled and imputed.
+NUMERIC_FEATURES: Sequence[str] = RAW_NUMERIC_INPUTS + (
     "tenure_years",  # Engineered feature
     "age_years",  # Engineered feature
     "years_since_last_review",  # Engineered feature

--- a/src/gui_app.py
+++ b/src/gui_app.py
@@ -35,7 +35,7 @@ import streamlit as st
 from plotly.subplots import make_subplots
 
 try:
-    from .feature_engineering import CATEGORICAL_FEATURES, NUMERIC_FEATURES
+    from .feature_engineering import CATEGORICAL_FEATURES, RAW_NUMERIC_INPUTS
     from .inference import (
         DEFAULT_MODEL_PATH,
         DEFAULT_TENURE_HORIZONS,
@@ -45,7 +45,7 @@ try:
     )
     from .logging_utils import configure_logging, get_logger
 except ImportError:  # pragma: no cover - fallback for script execution
-    from feature_engineering import CATEGORICAL_FEATURES, NUMERIC_FEATURES
+    from feature_engineering import CATEGORICAL_FEATURES, RAW_NUMERIC_INPUTS
     from inference import (
         DEFAULT_MODEL_PATH,
         DEFAULT_TENURE_HORIZONS,
@@ -114,7 +114,7 @@ def prepare_reference_metadata() -> Tuple[Dict[str, List], Dict[str, float], Dic
             categorical_options[column] = options or ["Unknown"]
 
     # Use median for numeric defaults
-    for column in NUMERIC_FEATURES:
+    for column in RAW_NUMERIC_INPUTS:
         if column in dataset.columns:
             numeric_defaults[column] = float(dataset[column].dropna().median())
 
@@ -129,7 +129,7 @@ def prepare_reference_metadata() -> Tuple[Dict[str, List], Dict[str, float], Dic
     today = pd.Timestamp.today().date()
     for column in DATE_FIELDS:
         date_defaults.setdefault(column, today)
-    for column in NUMERIC_FEATURES:
+    for column in RAW_NUMERIC_INPUTS:
         numeric_defaults.setdefault(column, 0.0)
 
     return categorical_options, numeric_defaults, date_defaults
@@ -296,7 +296,7 @@ with single_tab:
         for i, col_name in enumerate(CATEGORICAL_FEATURES):
             with form_cols[i % 3]:
                 record[col_name] = st.selectbox(col_name, options=categorical_options.get(col_name, ["Unknown"]))
-        for i, col_name in enumerate(NUMERIC_FEATURES):
+        for i, col_name in enumerate(RAW_NUMERIC_INPUTS):
             with form_cols[i % 3]:
                 record[col_name] = st.number_input(col_name, value=numeric_defaults.get(col_name, 0.0))
         for i, col_name in enumerate(DATE_FIELDS):

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import feature_engineering as fe  # noqa: E402
+
+
+def test_raw_numeric_inputs_exclude_engineered_features():
+    engineered = {"tenure_years", "age_years", "years_since_last_review"}
+
+    assert not engineered.intersection(fe.RAW_NUMERIC_INPUTS)
+    for column in fe.RAW_NUMERIC_INPUTS:
+        assert column in fe.NUMERIC_FEATURES
+
+
+def test_prepare_inference_frame_recomputes_temporal_features():
+    record = {
+        "Salary": 75000,
+        "EngagementSurvey": 4.0,
+        "EmpSatisfaction": 3.0,
+        "SpecialProjectsCount": 2,
+        "DaysLateLast30": 1,
+        "Absences": 0,
+        "tenure_years": 25.0,  # Should be ignored in favour of date-derived value
+        "age_years": 80.0,  # Should be ignored in favour of date-derived value
+        "DateofHire": "2020-01-01",
+        "DateofTermination": "2021-01-01",
+        "DOB": "1990-01-01",
+        "LastPerformanceReview_Date": "2020-06-01",
+    }
+
+    prepared = fe.prepare_inference_frame(record)
+
+    tenure_years = prepared.loc[0, "tenure_years"]
+    age_years = prepared.loc[0, "age_years"]
+
+    expected_tenure = (
+        pd.Timestamp("2021-01-01") - pd.Timestamp("2020-01-01")
+    ).days / 365.25
+    # Reference date resolves from the first available event column (last review here).
+    resolved_reference = pd.Timestamp("2020-06-01")
+    expected_age = (
+        resolved_reference - pd.Timestamp("1990-01-01")
+    ).days / 365.25
+
+    assert abs(tenure_years - expected_tenure) < 1e-6
+    assert abs(age_years - expected_age) < 1e-6


### PR DESCRIPTION
## Summary
- add a RAW_NUMERIC_INPUTS collection alongside the engineered feature list
- update the GUI metadata preparation and single-record form to rely on the raw numeric inputs
- add feature-engineering tests to cover the new helper and ensure temporal fields are derived from dates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6901a9a7bab483309ecf3675c680e070