### PR TITLE
Add fairness analysis module and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup lint test train evaluate report app reproduce clean help
+.PHONY: setup lint test train fairness evaluate report app reproduce clean help
 
 # Default target
 .DEFAULT_GOAL := help
@@ -39,6 +39,10 @@ test:  ## Run unit tests with coverage
 
 train:  ## Train the model from scratch
 	$(PYTHON) $(SRC_DIR)/train_model.py
+	$(PYTHON) $(SRC_DIR)/fairness_analysis.py
+
+fairness:  ## Run fairness and bias analysis on the held-out test set
+	$(PYTHON) $(SRC_DIR)/fairness_analysis.py
 
 evaluate:  ## Evaluate the trained model and generate metrics
 	@echo "Metrics are generated during training. Check $(REPORTS_DIR)/metrics_with_ci.json"

--- a/README.md
+++ b/README.md
@@ -358,6 +358,22 @@ Our models significantly outperform trivial baselines.
 - **Calibration Curve:** `reports/figures/calibration.png` (Brier score: ~0.00)
 - **Feature Importance:** `reports/figures/perm_importance.png` (top 20 permutation importances)
 
+## Fairness & Responsible Use
+
+- Run `make fairness` (or the standalone `python src/fairness_analysis.py`) to
+  compute group-wise accuracy/recall/ROC-AUC, demographic parity difference,
+  and equal-opportunity difference for `RaceDesc`, `Sex`, `MaritalDesc`, and
+  `CitizenDesc`. Outputs land in `reports/fairness_summary.csv` plus bar charts
+  under `reports/figures/fairness_*.png`.
+- The current audit (47 test employees) shows the largest demographic parity
+  gap for **MaritalDesc** (0.57 between divorced and separated employees) and a
+  0.39 gap across race groups; several categories have only 1–2 examples so the
+  numbers carry high uncertainty.
+- Detailed findings, limitations, and a deployment warning live in
+  [`docs/FAIRNESS_AND_LIMITATIONS.md`](docs/FAIRNESS_AND_LIMITATIONS.md). The
+  model must only be used to flag retention risks for human review—**never** to
+  automate firing decisions.
+
 ## Ethical considerations
 - **Bias and fairness:** HR data may encode historical biases in hiring, promotion, or termination decisions. Monitor subgroup
   performance (e.g., by gender, race) to detect disparate impact.
@@ -392,6 +408,7 @@ Our models significantly outperform trivial baselines.
 ├── docs/
 │   ├── DATA_CARD.md                   # Dataset provenance, schema, leakage analysis
 │   ├── BUSINESS_ACTIONS.md            # Risk-based intervention framework
+│   ├── FAIRNESS_AND_LIMITATIONS.md    # Bias analysis summary + responsible use warning
 │   └── non_programmer_guide.md        # Beginner-friendly tutorial
 │
 ├── models/

--- a/docs/FAIRNESS_AND_LIMITATIONS.md
+++ b/docs/FAIRNESS_AND_LIMITATIONS.md
@@ -1,0 +1,69 @@
+# Fairness & Responsible Use Report
+
+This note summarises the bias/fairness audit that now runs as part of the
+training pipeline (`make train` automatically calls `python src/fairness_analysis.py`).
+The script reloads the persisted best model (`models/best_model.joblib`),
+recreates the canonical 70/15/15 train/validation/test split, and evaluates the
+held-out test set for the protected attributes available in the dataset:
+
+- `RaceDesc`
+- `Sex`
+- `MaritalDesc`
+- `CitizenDesc`
+
+For every group we compute accuracy, precision, recall, ROC-AUC, Brier score
+(calibration proxy), positive-prediction rate, demographic parity difference
+(max minus min positive-prediction rate within the attribute), and equal
+opportunity difference (max minus min recall for the positive class). The tidy
+output is saved to `reports/fairness_summary.csv` and mirrored in the bar charts
+stored under `reports/figures/fairness_<attribute>.png`.
+
+## Key findings (current dataset + model)
+
+| Attribute | Largest demographic parity gap | Largest equal opportunity gap | Notes |
+|-----------|--------------------------------|-------------------------------|-------|
+| RaceDesc | **0.39** between White (39% positive predictions) and Two or more races/American Indian (0%). | **1.00** because some groups have zero actual terminations in the test split, so recall collapses to 0. | Group counts range from 1–23 employees; treat these stats as directional only. |
+| Sex | 0.10 between men (29% positive predictions) and women (39%). | 0.00 because both groups achieved 100% recall on the tiny test slice. | Apparent parity is driven by the near-perfect test accuracy, not necessarily real-world equality. |
+| MaritalDesc | **0.57** between divorced employees (57% predicted positive) and separated employees (0%). | **1.00** for the same reason: some categories have no actual terminations. | Very small cells (e.g., only 2 separated or widowed employees). |
+| CitizenDesc | 0.01 between citizens and eligible non-citizens. | 0.00 with the current test set. | Counts are still small (3 non-citizens). |
+
+Interpretation tips:
+
+- Perfect accuracy/recall numbers reflect the tiny test set (47 employees) and
+  oversampled training regime; they **do not** guarantee the absence of bias.
+- Demographic parity gaps above ~0.2 already warrant investigation, but here the
+  largest gaps coincide with groups that contain ≤2 people. Statistical
+  confidence is therefore extremely low.
+
+## Limitations & warnings
+
+1. **Sample size** – The test split contains only 47 employees. Several protected
+   groups have 1–3 members, so any gap can swing wildly with a single record.
+2. **Historical bias** – The raw HR dataset may encode biased termination
+   decisions. The model learns from that history; even perfect parity on this
+   dataset would not prove fairness in practice.
+3. **Feature coverage** – We only audited attributes present in the dataset.
+   Other sensitive traits (disability status, parental leave history, etc.) are
+   missing entirely and therefore unaudited.
+4. **Model confidence** – Reported recall/precision of 1.0 stems from
+   overfitting on a small sample. Real-world deployment will introduce errors
+   that may not be evenly distributed across groups.
+5. **Responsible use** – The model must **never** be used as an automated firing
+   engine. It is designed to surface retention risks for **human review**, not
+   to trigger adverse employment actions without context.
+
+## How to reproduce
+
+Run the fairness module directly or via the Makefile once the best model exists:
+
+```bash
+# Stand-alone run
+python src/fairness_analysis.py
+
+# Part of the full pipeline
+make train   # trains + runs fairness analysis automatically
+make fairness  # re-run audit using the persisted model
+```
+
+Inspect the generated CSV/figures alongside this document before sharing
+predictions with stakeholders.

--- a/src/fairness_analysis.py
+++ b/src/fairness_analysis.py
@@ -1,0 +1,260 @@
+"""Bias and fairness diagnostics for the termination prediction models.
+
+This module loads the persisted best model, recreates the canonical
+train/validation/test split, and computes group-level performance metrics
+for sensitive attributes that exist in the dataset (RaceDesc, Sex,
+MaritalDesc, CitizenDesc).  The goal is to provide lightweight fairness
+checks—demographic parity and equal opportunity gaps—without introducing
+additional heavy dependencies.
+
+The script can be executed directly or invoked through the Makefile via
+`make fairness`.  Outputs are written to `reports/`:
+
+* `fairness_summary.csv`: tidy table with per-group metrics and gaps
+* `figures/fairness_<attribute>.png`: optional bar charts for quick review
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, List
+
+import joblib
+import numpy as np
+import pandas as pd
+from sklearn.metrics import (
+    accuracy_score,
+    brier_score_loss,
+    precision_score,
+    recall_score,
+    roc_auc_score,
+)
+
+try:  # pragma: no cover - import guard for script vs. module usage
+    from .constants import RANDOM_SEED
+    from .feature_engineering import prepare_training_data
+    from .logging_utils import configure_logging, get_logger
+    from .train_model import stratified_splits
+except ImportError:  # pragma: no cover - fallback for CLI execution
+    from constants import RANDOM_SEED  # type: ignore
+    from feature_engineering import prepare_training_data  # type: ignore
+    from logging_utils import configure_logging, get_logger  # type: ignore
+    from train_model import stratified_splits  # type: ignore
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DATA_PATH = PROJECT_ROOT / "HRDataset_v14.csv"
+DEFAULT_MODEL_PATH = PROJECT_ROOT / "models" / "best_model.joblib"
+DEFAULT_SUMMARY_PATH = PROJECT_ROOT / "reports" / "fairness_summary.csv"
+DEFAULT_FIGURES_DIR = PROJECT_ROOT / "reports" / "figures"
+
+PROTECTED_ATTRIBUTES = ("RaceDesc", "Sex", "MaritalDesc", "CitizenDesc")
+
+logger = get_logger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    """Return CLI arguments for fairness computation."""
+
+    parser = argparse.ArgumentParser(description="Fairness/bias diagnostics for termination model")
+    parser.add_argument("--data", type=Path, default=DEFAULT_DATA_PATH, help="Path to HRDataset CSV")
+    parser.add_argument("--model", type=Path, default=DEFAULT_MODEL_PATH, help="Path to trained model pipeline")
+    parser.add_argument(
+        "--output", type=Path, default=DEFAULT_SUMMARY_PATH, help="Destination CSV for fairness summary"
+    )
+    parser.add_argument(
+        "--figures-dir",
+        type=Path,
+        default=DEFAULT_FIGURES_DIR,
+        help="Directory to store fairness bar charts",
+    )
+    parser.add_argument(
+        "--attributes",
+        nargs="+",
+        default=list(PROTECTED_ATTRIBUTES),
+        help="Protected attributes to audit (must exist in processed feature set)",
+    )
+    parser.add_argument(
+        "--random-state",
+        type=int,
+        default=RANDOM_SEED,
+        help="Random seed so the canonical test split is reproduced",
+    )
+    parser.add_argument(
+        "--skip-figures",
+        action="store_true",
+        help="Skip generating matplotlib figures (still writes CSV summary)",
+    )
+    return parser.parse_args()
+
+
+def load_model(model_path: Path):
+    """Return the persisted model pipeline."""
+
+    if not model_path.exists():
+        raise FileNotFoundError(
+            f"Model artifact not found at {model_path}. Run `make train` before the fairness analysis."
+        )
+    return joblib.load(model_path)
+
+
+def prepare_test_split(data_path: Path, random_state: int):
+    """Load data, engineer features, and return the canonical test set."""
+
+    df = pd.read_csv(data_path)
+    X, y = prepare_training_data(df)
+    splits = stratified_splits(X, y, random_state=random_state)
+    return splits.X_test.reset_index(drop=True), splits.y_test.reset_index(drop=True)
+
+
+def _safe_roc_auc(y_true: pd.Series, y_prob: np.ndarray) -> float:
+    """Compute ROC-AUC when both classes are present; otherwise return NaN."""
+
+    if y_true.nunique() < 2:
+        return float("nan")
+    return float(roc_auc_score(y_true, y_prob))
+
+
+def _safe_brier(y_true: pd.Series, y_prob: np.ndarray) -> float:
+    if len(y_prob) == 0:
+        return float("nan")
+    return float(brier_score_loss(y_true, y_prob))
+
+
+def compute_group_metrics(
+    X_test: pd.DataFrame,
+    y_test: pd.Series,
+    y_pred: np.ndarray,
+    y_prob: np.ndarray,
+    attributes: Iterable[str],
+) -> pd.DataFrame:
+    """Return tidy DataFrame with fairness metrics for each attribute/group."""
+
+    records: List[dict] = []
+
+    for attribute in attributes:
+        if attribute not in X_test.columns:
+            logger.warning("Attribute %s not found in test features; skipping", attribute)
+            continue
+
+        attr_series = X_test[attribute].fillna("Unknown").astype(str)
+        attr_rows: List[dict] = []
+        pred_rates: List[float] = []
+        recalls: List[float] = []
+
+        for group_value in sorted(attr_series.unique()):
+            mask = attr_series == group_value
+            if not mask.any():
+                continue
+
+            y_true_group = y_test[mask]
+            y_pred_group = y_pred[mask]
+            y_prob_group = y_prob[mask]
+
+            accuracy = float(accuracy_score(y_true_group, y_pred_group))
+            precision = float(precision_score(y_true_group, y_pred_group, zero_division=0))
+            recall = float(recall_score(y_true_group, y_pred_group, zero_division=0))
+            roc_auc = _safe_roc_auc(y_true_group, y_prob_group)
+            brier = _safe_brier(y_true_group, y_prob_group)
+            pred_positive_rate = float((y_pred_group == 1).mean())
+            true_positive_rate = float(y_true_group.mean())
+
+            attr_rows.append(
+                {
+                    "attribute": attribute,
+                    "group": group_value,
+                    "sample_size": int(mask.sum()),
+                    "positive_rate": true_positive_rate,
+                    "pred_positive_rate": pred_positive_rate,
+                    "accuracy": accuracy,
+                    "precision": precision,
+                    "recall": recall,
+                    "roc_auc": roc_auc,
+                    "brier_score": brier,
+                }
+            )
+            pred_rates.append(pred_positive_rate)
+            recalls.append(recall)
+
+        if not attr_rows:
+            continue
+
+        dp_diff = float(np.nanmax(pred_rates) - np.nanmin(pred_rates)) if len(pred_rates) > 1 else 0.0
+        eo_diff = float(np.nanmax(recalls) - np.nanmin(recalls)) if len(recalls) > 1 else 0.0
+
+        for row in attr_rows:
+            row["demographic_parity_difference"] = dp_diff
+            row["equal_opportunity_difference"] = eo_diff
+
+        logger.info(
+            "Attribute %s → demographic parity diff %.3f, equal opportunity diff %.3f",
+            attribute,
+            dp_diff,
+            eo_diff,
+        )
+        records.extend(attr_rows)
+
+    return pd.DataFrame(records)
+
+
+def plot_attribute_bars(attribute: str, summary_df: pd.DataFrame, figures_dir: Path) -> None:
+    """Persist a simple bar chart for positive prediction rates and recall per group."""
+
+    import matplotlib.pyplot as plt
+
+    attr_df = summary_df[summary_df["attribute"] == attribute]
+    if attr_df.empty:
+        return
+
+    figures_dir.mkdir(parents=True, exist_ok=True)
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 4))
+    axes[0].bar(attr_df["group"], attr_df["pred_positive_rate"], color="#1f77b4")
+    axes[0].set_title("Positive prediction rate")
+    axes[0].set_ylabel("Rate")
+    axes[0].tick_params(axis="x", labelrotation=45)
+
+    axes[1].bar(attr_df["group"], attr_df["recall"], color="#ff7f0e")
+    axes[1].set_title("Recall (equal opportunity)")
+    axes[1].tick_params(axis="x", labelrotation=45)
+
+    fig.suptitle(f"Fairness diagnostics for {attribute}")
+    fig.tight_layout()
+    output_path = figures_dir / f"fairness_{attribute.lower()}.png"
+    fig.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)
+    logger.info("Saved fairness figure for %s to %s", attribute, output_path)
+
+
+def run_fairness_audit(args: argparse.Namespace) -> Path:
+    """Execute fairness analysis end-to-end and return summary path."""
+
+    model = load_model(args.model)
+    X_test, y_test = prepare_test_split(args.data, random_state=args.random_state)
+    y_pred = model.predict(X_test)
+    y_prob = model.predict_proba(X_test)[:, 1]
+
+    summary_df = compute_group_metrics(X_test, y_test, y_pred, y_prob, args.attributes)
+    if summary_df.empty:
+        raise RuntimeError("No fairness metrics were computed; ensure attributes exist in the dataset.")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    summary_df.to_csv(args.output, index=False)
+    logger.info("Wrote fairness summary to %s", args.output)
+
+    if not args.skip_figures:
+        for attribute in summary_df["attribute"].unique():
+            plot_attribute_bars(attribute, summary_df, args.figures_dir)
+
+    return args.output
+
+
+def main() -> None:
+    configure_logging()
+    args = parse_args()
+    summary_path = run_fairness_audit(args)
+    print(f"Fairness summary saved to {summary_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a reusable `fairness_analysis.py` script that reloads the trained pipeline, reproduces the canonical test split, and saves group-level metrics/figures for sensitive attributes
- wire the script into the Makefile (new `make fairness` target and automatic execution after `make train`) and add a dedicated fairness & responsible use section to the README
- document the findings, limitations, and responsible-use warning in `docs/FAIRNESS_AND_LIMITATIONS.md`

## Testing
- python -m pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad9605c4c8330a0b835ebc2174fef)