### PR TITLE
Add configuration-driven experiment training support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ Feature preparation is centralized in [`src/feature_engineering.py`](src/feature
 
 ### Quick Training
 ```bash
+# Legacy CLI options
 python src/train_model.py
+
+# Configuration-driven experiments
+python src/train_model.py --config configs/experiments/default.yaml
 ```
 
 The script:
@@ -115,6 +119,8 @@ Test metrics are reported with **95% confidence intervals** using 1000 bootstrap
 | ROC-AUC | 1.000 | 0.995 | 1.000 |
 
 **Calibration:** Brier score and reliability curve assess probability calibration (see `reports/figures/calibration.png`).
+
+See [`configs/README.md`](configs/README.md) for details on creating new YAML experiments (feature overrides, CV settings, and hyperparameter grids).
 
 ---
 

--- a/configs/README.md
+++ b/configs/README.md
@@ -1,0 +1,49 @@
+# Experiment Configuration Guide
+
+Experiment YAML files live under `configs/experiments/` and describe every aspect of a training run. Each file mirrors the structure consumed by `src/train_model.py --config ...`.
+
+## File Structure
+
+```yaml
+data:
+  dataset_path: ../../HRDataset_v14.csv
+
+preprocessing:
+  include_numeric_features:
+    - Salary
+  exclude_numeric_features:
+    - Absences
+  include_categorical_features:
+    - Department
+  exclude_categorical_features:
+    - State
+
+models:
+  custom_rf:
+    type: random_forest
+    model_parameters:
+      class_weight: balanced
+    hyperparameters:
+      model__n_estimators: [100, 200]
+      model__max_depth: [8, 12]
+
+cross_validation:
+  n_splits: 5
+  shuffle: true
+  random_state: 42
+```
+
+### Sections
+- **data** – absolute or relative path to the CSV dataset. Relative paths resolve from the config file's directory.
+- **preprocessing** – optional lists to explicitly include or exclude numeric/categorical features. Omitted fields fall back to the defaults in `src/feature_engineering.py`.
+- **models** – dictionary of model definitions. Each key becomes the model name in metrics. Provide:
+  - `type`: one of `logistic_regression`, `random_forest`, or `gradient_boosting`.
+  - `model_parameters` *(optional)*: base estimator keyword arguments (e.g., `class_weight`).
+  - `hyperparameters`: parameter grid passed directly to `GridSearchCV`.
+- **cross_validation** – values forwarded to `StratifiedKFold`.
+
+## Tips
+- Start from `experiments/lightweight.yaml` for quick smoke tests.
+- Duplicate `experiments/default.yaml` for full reproductions.
+- Keep grids small when experimenting to avoid long runtimes.
+- Store custom experiment files alongside the provided templates to simplify version control.

--- a/configs/experiments/default.yaml
+++ b/configs/experiments/default.yaml
@@ -1,0 +1,49 @@
+# Default experiment configuration mirroring the legacy training behaviour.
+data:
+  dataset_path: ../../HRDataset_v14.csv
+
+preprocessing:
+  include_numeric_features:
+    - Salary
+    - EngagementSurvey
+    - EmpSatisfaction
+    - SpecialProjectsCount
+    - DaysLateLast30
+    - Absences
+    - tenure_years
+    - age_years
+    - years_since_last_review
+  include_categorical_features:
+    - Department
+    - PerformanceScore
+    - RecruitmentSource
+    - Position
+    - State
+    - Sex
+    - MaritalDesc
+    - CitizenDesc
+    - RaceDesc
+    - HispanicLatino
+
+models:
+  logistic_regression:
+    type: logistic_regression
+    hyperparameters:
+      model__C: [0.1, 1.0, 10.0]
+  random_forest:
+    type: random_forest
+    hyperparameters:
+      model__n_estimators: [200, 400]
+      model__max_depth: [null, 10, 16]
+      model__min_samples_split: [2, 5]
+  gradient_boosting:
+    type: gradient_boosting
+    hyperparameters:
+      model__n_estimators: [150, 250]
+      model__learning_rate: [0.05, 0.1]
+      model__max_depth: [2, 3]
+
+cross_validation:
+  n_splits: 5
+  shuffle: true
+  random_state: 42

--- a/configs/experiments/lightweight.yaml
+++ b/configs/experiments/lightweight.yaml
@@ -1,0 +1,28 @@
+# Lightweight configuration for quick experiments or CI smoke tests.
+data:
+  dataset_path: ../../HRDataset_v14.csv
+
+preprocessing:
+  include_numeric_features:
+    - Salary
+    - tenure_years
+    - years_since_last_review
+  include_categorical_features:
+    - Department
+    - PerformanceScore
+
+models:
+  logistic_quick:
+    type: logistic_regression
+    hyperparameters:
+      model__C: [1.0]
+  random_forest_quick:
+    type: random_forest
+    hyperparameters:
+      model__n_estimators: [100]
+      model__max_depth: [8]
+
+cross_validation:
+  n_splits: 3
+  shuffle: true
+  random_state: 42

--- a/tests/test_train_model_config.py
+++ b/tests/test_train_model_config.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+from src import train_model
+
+
+def test_run_training_with_toy_config(tmp_path, monkeypatch):
+    dataset_path = Path("HRDataset_v14.csv")
+    df = pd.read_csv(dataset_path)
+    positives = df[df["Termd"] == 1].head(12)
+    negatives = df[df["Termd"] == 0].head(12)
+    toy_df = pd.concat([positives, negatives]).sample(frac=1.0, random_state=0).reset_index(drop=True)
+    toy_csv = tmp_path / "toy_dataset.csv"
+    toy_df.to_csv(toy_csv, index=False)
+
+    config_payload = {
+        "data": {"dataset_path": str(toy_csv)},
+        "preprocessing": {
+            "include_numeric_features": ["Salary", "EngagementSurvey"],
+            "include_categorical_features": ["Department"],
+        },
+        "models": {
+            "toy_logistic": {
+                "type": "logistic_regression",
+                "hyperparameters": {"model__C": [1.0]},
+            }
+        },
+        "cross_validation": {"n_splits": 2, "shuffle": True, "random_state": 0},
+    }
+    config_path = tmp_path / "toy_config.yaml"
+    config_path.write_text(yaml.safe_dump(config_payload))
+
+    experiment_config = train_model.load_experiment_config(config_path)
+
+    tmp_reports = tmp_path / "reports"
+    monkeypatch.setattr(train_model, "REPORTS_DIR", tmp_reports)
+    monkeypatch.setattr(train_model, "FIGURES_DIR", tmp_reports / "figures")
+    monkeypatch.setattr(train_model, "compute_and_save_metrics_with_ci", lambda *args, **kwargs: {})
+    monkeypatch.setattr(train_model, "generate_diagnostic_plots", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_model, "analyze_failures_from_test", lambda *args, **kwargs: None)
+    monkeypatch.setattr(train_model, "save_split_summary", lambda *args, **kwargs: None)
+
+    model_output = tmp_path / "model.joblib"
+    metrics_output = tmp_path / "metrics.json"
+
+    result = train_model.run_training(
+        data_path=toy_csv,
+        model_path=model_output,
+        metrics_path=metrics_output,
+        random_state=0,
+        experiment_config=experiment_config,
+    )
+
+    assert result.name == "toy_logistic"
+    assert model_output.exists()
+    assert metrics_output.exists()


### PR DESCRIPTION
## Summary
- refactor `src/train_model.py` to load experiment settings from YAML configs, including feature overrides, model grids, and CV parameters, and wire the flag into the CLI
- add documented default/lightweight experiment templates under `configs/` so new runs can be configured declaratively
- add a regression test that runs the training loop with a toy config to ensure parsing and execution work

## Testing
- .venv/bin/python -m pytest tests/test_train_model_config.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ae3d50a7883309d30eb848029a544)